### PR TITLE
Dev/web archiving docs

### DIFF
--- a/docs/web-archiving.md
+++ b/docs/web-archiving.md
@@ -1,0 +1,11 @@
+## Rendering Web Archives
+
+Curate supports in-browser rendering of web archive files in both WARC and WACZ formats. To render a web archive, simply double-click the file in the file list. Curate will open the archive using [ReplayWebPage](https://replayweb.page/), allowing you to browse the archived content directly in your browser.
+
+### WACZ Files
+
+WACZ (Web Archive Collection Zipped) is the recommended format for web archives in Curate. WACZ files include a built-in index, which enables full browsing of the archived collection — you can navigate pages, search within the archive, and explore the full list of captured URLs.
+
+### WARC Files
+
+WARC files are also supported for rendering. Because WARC files do not include an index, the browsing experience differs slightly from WACZ: rather than a full collection view, ReplayWebPage will attempt to replay the content that is available in the file directly.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,7 @@ nav:
   - Preservation: preservation.md
   - Packaging: packaging.md
   - Email Processing: email-processing.md
+  - Web Archiving: web-archiving.md
   - Miscellaneous: miscellaneous.md
   - Search & Access: search-access.md
   - Security: security.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,7 @@ nav:
   - Integrations: integrations.md
   - Exporting Metadata: exporting-metadata.md
 plugins:
+  - search
   - redirects:
       redirect_maps:
         'documentation.md': 'index.markdown'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * New web archiving documentation section providing instructions on how to open and use WARC/WACZ archive files in ReplayWebPage
  * Explains key differences in user experience: WACZ files include a built-in index for full collection navigation and search, while WARC files are replayed directly without index support
  * Documentation search functionality enabled to help users find information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->