### PR TITLE
docs: fix typos, trademark spacing, and characterisation tools list

### DIFF
--- a/docs/application-areas.md
+++ b/docs/application-areas.md
@@ -1,6 +1,6 @@
 ## Home Screen
 
-When you log in to Curate <span style="font-size: 8pt;vertical-align: super;">TM</span> you will see the home screen as shown
+When you log in to Curate<span style="font-size: 8pt;vertical-align: super;">TM</span> you will see the home screen as shown
 below and you will be guided through a short welcome tour. The home
 screen provides you with links to recent content, and ways to navigate
 through the rest of the application.
@@ -76,7 +76,7 @@ your own personal content, which would not normally be part of a group
 archive.
 
 Files uploaded into Personal are virus checked once and cannot be moved
-out into any other area of Curate <span style="font-size: 8pt;vertical-align: super;">TM</span>.
+out into any other area of Curate<span style="font-size: 8pt;vertical-align: super;">TM</span>.
 
 If you have files in Personal that you later want to add to the archive,
 you will need to re-upload into Quarantine, or if you don't have a local
@@ -90,12 +90,12 @@ content.
 
 ### Quarantine Space
 
-Content that is to be appraised and arranged in Curate <span style="font-size: 8pt;vertical-align: super;">TM</span> should be
+Content that is to be appraised and arranged in Curate<span style="font-size: 8pt;vertical-align: super;">TM</span> should be
 uploaded into the Quarantine workspace [(_see upload and ingest for more information_)](upload-ingest.md). This is a shared workspace and so is visible to all
 members of a workgroup. Uploaded files are virus checked and quarantined
 for 30 days. It is recommended that files should not be moved from the
 Quarantine workspace until the quarantine period is up, however
-Curate <span style="font-size: 8pt;vertical-align: super;">TM</span> is not prescriptive and you can choose to move files out early if you wish.
+Curate<span style="font-size: 8pt;vertical-align: super;">TM</span> is not prescriptive and you can choose to move files out early if you wish.
 
 If the virus scanner detects a virus or malware then the affected file
 will be moved to a folder called Infected within the Quarantine

--- a/docs/appraisal.md
+++ b/docs/appraisal.md
@@ -1,7 +1,7 @@
 ## Move Content into Appraisal
 
 Files will be moved into the Appraisal workspace when they have
-completed quarantine and two successful virus scans. Curate <span style="font-size: 8pt;vertical-align: super;">TM</span> is not
+completed quarantine and two successful virus scans. Curate<span style="font-size: 8pt;vertical-align: super;">TM</span> is not
 prescriptive however and you can move data early. The Appraisal
 workspace is used to create arrangements (folder structures containing
 your files), conduct content appraisal helped by the file information
@@ -10,7 +10,7 @@ available and to create descriptions.
 Try moving files and folders from the Quarantine workspace into
 Appraisal. You can do this by selecting, right clicking and selecting
 Move or by dragging and dropping to a different workspace in the listing
-in the lefthand column. Multiple files or folders can be selected for
+in the left hand column. Multiple files or folders can be selected for
 each move using the usual Control or Shift operations.
 
 <div class="main-content-img-container">
@@ -21,7 +21,7 @@ Note that if files are moved into Appraisal early (i.e. before the
 quarantine period is up) then the Quarantine Status tag changes to Risk
 to indicate that full quarantine conditions were not met.
 
-Once you have files in the Appraisal workspace, Curate <span style="font-size: 8pt;vertical-align: super;">TM</span> runs
+Once you have files in the Appraisal workspace, Curate<span style="font-size: 8pt;vertical-align: super;">TM</span> runs
 comprehensive file characterisation programmes. To access the generated
 characterization information, select a file and check the file
 information panel in the object information area. [(_see File Information Panel_)](application-areas.md#file-information-panel). Characterised objects will include these fields in their
@@ -63,8 +63,8 @@ it goes in the system.
 ### Describing a Single File or Folder
 
 Descriptive metadata is used to annotate a file, folder or group of
-files in a folder structure. All descriptive metadata in Curate <span style="font-size: 8pt;vertical-align: super;">TM</span> is
-indexed and searchable [(_see search_)](search-access.md). Curate <span style="font-size: 8pt;vertical-align: super;">TM</span> provides both the
+files in a folder structure. All descriptive metadata in Curate<span style="font-size: 8pt;vertical-align: super;">TM</span> is
+indexed and searchable [(_see search_)](search-access.md). Curate<span style="font-size: 8pt;vertical-align: super;">TM</span> provides both the
 Dublin Core simple 15 element schema which you can read about in detail
 (if you want to) <a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#section-3">here</a>
 and the full General International Standard Archival Description ISAD(G)
@@ -73,7 +73,7 @@ descriptive metadata schema which you can read more about <a href="https://www.i
 You can be as precise as you wish with the use of metadata elements by
 following the specifications and controlled vocabularies. Alternatively,
 you can just use those elements you wish, in the way that suits you,
-(for example by putting a title in for each file). Curate <span style="font-size: 8pt;vertical-align: super;">TM</span> does not
+(for example by putting a title in for each file). Curate<span style="font-size: 8pt;vertical-align: super;">TM</span> does not
 impose rules.
 
 To begin to describe any file or folder in Curate, select the object you
@@ -142,7 +142,7 @@ files in your selection will be updated.
 
 ## Importing Metadata
 
-Curate <span style="font-size: 8pt;vertical-align: super;">TM</span> allows you to import metadata from external sources into your Curate instance. You can import metadata from:
+Curate<span style="font-size: 8pt;vertical-align: super;">TM</span> allows you to import metadata from external sources into your Curate instance. You can import metadata from:
 
 - CSV files
 - OAI-PMH repositories
@@ -176,7 +176,7 @@ If you have persistent problems, please contact us for help.
 
 ## Creating a Report on File Types
 
-Curate <span style="font-size: 8pt;vertical-align: super;">TM</span> identifies file types via a MIME type and a PRONOM ID. You
+Curate<span style="font-size: 8pt;vertical-align: super;">TM</span> identifies file types via a MIME type and a PRONOM ID. You
 can generate detailed reports of the MIME types, for example to create a
 digital asset register, for any aggregation of files or folders. Try
 going to a high-level folder that contains other folders and files,
@@ -191,7 +191,7 @@ report as a CSV file.
 
 ## Creating a Transfer Package or SIP
 
-Curate <span style="font-size: 8pt;vertical-align: super;">TM</span> can create packages or SIPs for submission to repositories or
+Curate<span style="font-size: 8pt;vertical-align: super;">TM</span> can create packages or SIPs for submission to repositories or
 digital preservation platforms such as: Archivematica, Preservica and
 EARK compliant systems using the templates in the Package Templates
 workspace. We can give you a demonstration of package creation if you

--- a/docs/index.markdown
+++ b/docs/index.markdown
@@ -8,9 +8,9 @@
   </button>
 </div>
 
-# Penwern Curate <span style="font-size: 8pt;vertical-align: super;">TM</span>
+# Penwern Curate<span style="font-size: 8pt;vertical-align: super;">TM</span>
 
-Penwern Curate <span style="font-size: 8pt;vertical-align: super;">TM</span> is a comprehensive software platform that addresses
+Penwern Curate<span style="font-size: 8pt;vertical-align: super;">TM</span> is a comprehensive software platform that addresses
 the fundamental issues with existing Digital Archiving solutions,
 allowing organisations of any size to build, preserve and manage
 best-practice Digital Archives with ground-breaking speed and
@@ -34,7 +34,7 @@ untrustworthy due to a number of factors, such as:
 - You cannot find specific files due to a lack of understandable
   organisation or description.
 
-Curate <span style="font-size: 8pt;vertical-align: super;">TM</span> helps to fix these problems by:
+Curate<span style="font-size: 8pt;vertical-align: super;">TM</span> helps to fix these problems by:
 
 - Removing threats due to viruses and malware through a system or
   virus checks and quarantine.
@@ -61,12 +61,12 @@ Curate <span style="font-size: 8pt;vertical-align: super;">TM</span> helps to fi
 - Preparing your content into standards-conformant information
   packages.
 
-## Is Curate <span style="font-size: 8pt;vertical-align: super;">TM</span> Useful for Archivists and Digital Curators?
+## Is Curate<span style="font-size: 8pt;vertical-align: super;">TM</span> Useful for Archivists and Digital Curators?
 
-Curate <span style="font-size: 8pt;vertical-align: super;">TM</span> is a platform that can be used to provide a number of
+Curate<span style="font-size: 8pt;vertical-align: super;">TM</span> is a platform that can be used to provide a number of
 critical functions within an electronic archiving system discretely or
 can form a complete and effective system itself. Individually,
-Curate <span style="font-size: 8pt;vertical-align: super;">TM</span> can perform the following roles:
+Curate<span style="font-size: 8pt;vertical-align: super;">TM</span> can perform the following roles:
 
 - Ingest, Upload and Accession
 
@@ -100,9 +100,9 @@ In combination, these services mean that Curate comprises a
 comprehensive and highly capable electronic archiving system all on its
 own.
 
-## Is Curate <span style="font-size: 8pt;vertical-align: super;">TM</span> Useful for Business?
+## Is Curate<span style="font-size: 8pt;vertical-align: super;">TM</span> Useful for Business?
 
-Curate <span style="font-size: 8pt;vertical-align: super;">TM</span> is a file sharing platform that integrates the features
+Curate<span style="font-size: 8pt;vertical-align: super;">TM</span> is a file sharing platform that integrates the features
 required for the preservation of data that go beyond basic data
 protection (back-up, integrity checking, disaster recovery).
 
@@ -115,7 +115,7 @@ digital preservation and eArchiving.
 It is cost effective, allowing you to create an archive for inactive
 data that doesn't take up valuable storage on your primary storage
 systems and allows you to consolidate data into a single platform.
-Curate <span style="font-size: 8pt;vertical-align: super;">TM</span> works in a way your users understand, with a best-in-class
+Curate<span style="font-size: 8pt;vertical-align: super;">TM</span> works in a way your users understand, with a best-in-class
 user experience. You don't have to train all your users on new, complex
 digital preservation applications.
 

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -25,13 +25,13 @@ Curate integrates with AtoM, an open-source archival description management syst
 
 To connect your Curate instance to AtoM, you will first need to follow the standard installation instructions for AtoM (see [AtoM installation instructions](https://www.accesstomemory.org/en/docs/latest/#installation)). Once AtoM is installed, you will need to correctly configure AtoM to enable the Sword API (see [AtoM Sword API configuration](https://www.archivematica.org/en/docs/latest/admin-manual/installation-setup/integrations/atom-setup/#configure-dip-upload)). Once AtoM is installed and configured, please proceed to the following section [connecting to AtoM](#connecting-to-atom)
 
-NB: the configuration steps reference Archivematica <span style="font-size: 8pt;vertical-align: super;">TM</span>, but the same process can be used with Curate. Please see the above warning for more information about configuring SSH keys between Curate and AtoM.
+NB: the configuration steps reference Archivematica<span style="font-size: 8pt;vertical-align: super;">TM</span>, but the same process can be used with Curate. Please see the above warning for more information about configuring SSH keys between Curate and AtoM.
 
 <div class="tip"> <span class="mdi mdi-information-outline"></span> <span>Please take care to ensure that the SWORD plugin and AtoM REST API are enabled on the AtoM plugins menu.</span> </div>
 
 **Explanation**
 
-Curate takes advantage of the Sword protocol to communicate with AtoM. This protocol allows AtoM to receive and process dissemination packages (DIPs) directly from Curate. The sword API is the mechanism AtoM internally uses to communicate DIP processing requests with its companion digital preservation system, Archivematica <span style="font-size: 8pt;vertical-align: super;">TM</span>. This enables Curate to streamline the process of uploading content into AtoM, and then linking it to existing archival descriptions.
+Curate takes advantage of the Sword protocol to communicate with AtoM. This protocol allows AtoM to receive and process dissemination packages (DIPs) directly from Curate. The sword API is the mechanism AtoM internally uses to communicate DIP processing requests with its companion digital preservation system, Archivematica<span style="font-size: 8pt;vertical-align: super;">TM</span>. This enables Curate to streamline the process of uploading content into AtoM, and then linking it to existing archival descriptions.
 
 #### Setting up AtoM (AtoM Hosted by your Curate Provider)
 

--- a/docs/preservation.md
+++ b/docs/preservation.md
@@ -1,4 +1,4 @@
-Curate <span style="font-size: 8pt;vertical-align: super;">TM</span> features a highly automated digital preservation service that
+Curate<span style="font-size: 8pt;vertical-align: super;">TM</span> features a highly automated digital preservation service that
 wraps the open source tool A3M into a dynamic workflow. Curate preservation workflows are highly configurable, simple to action,
 and automate the process of performing best-practice preservation and packaging actions on your files and folders.
 
@@ -6,7 +6,7 @@ Here's the enriched version with proper markdown formatting and escaping:
 
 ## About A3M
 
-A3M is an open-source tool, developed by Artefactual Systems <span style="font-size: 8pt;vertical-align: super;">TM</span>, that distills the essential preservation and packaging functionality of their widely-used platform Archivematica <span style="font-size: 8pt;vertical-align: super;">TM</span> into a specialised module. By removing unneeded components like the backend storage management and frontend-application while maintaining the same core code that powers digital archiving programs across the globe, A3M is able to provide reliable, comprehensive preservation and packaging functionalities in entirely new contexts.
+A3M is an open-source tool, developed by Artefactual Systems<span style="font-size: 8pt;vertical-align: super;">TM</span>, that distills the essential preservation and packaging functionality of their widely-used platform Archivematica<span style="font-size: 8pt;vertical-align: super;">TM</span> into a specialised module. By removing unneeded components like the backend storage management and frontend-application while maintaining the same core code that powers digital archiving programs across the globe, A3M is able to provide reliable, comprehensive preservation and packaging functionalities in entirely new contexts.
 
 <a href="https://a3m.readthedocs.io/en/latest/">Read the A3M documentation</a>
 
@@ -145,10 +145,10 @@ A3M uses a set of specialised tools to analyze your files and extract detailed t
 
 A3M utilizes the following industry-standard tools for file characterization:
 
-<a href="http://ffmpeg.org/">FFProbe</a>: A powerful multimedia stream analyzer that provides detailed information about audio and video files
-<a href="http://mediaarea.net/en/MediaInfo">MediaInfo</a>: A versatile tool that extracts technical and tag data from video and audio files
-<a href="https://exiftool.org/index.html">ExifTool</a>: A comprehensive metadata extraction tool that supports a wide range of file formats
-<a href="https://forensicswiki.xyz/wiki/index.php?title=Fiwalk">Fiwalk</a>: A command-line tool for analyzing and extracting metadata from disk images and file systems
+- <a href="http://ffmpeg.org/">FFProbe</a>: A powerful multimedia stream analyzer that provides detailed information about audio and video files.
+- <a href="http://mediaarea.net/en/MediaInfo">MediaInfo</a>: A versatile tool that extracts technical and tag data from video and audio files.
+- <a href="https://exiftool.org/index.html">ExifTool</a>: A comprehensive metadata extraction tool that supports a wide range of file formats.
+- <a href="https://forensicswiki.xyz/wiki/index.php?title=Fiwalk">Fiwalk</a>: A command-line tool for analyzing and extracting metadata from disk images and file systems.
 
 ### Normalisation
 

--- a/docs/search-access.md
+++ b/docs/search-access.md
@@ -1,12 +1,12 @@
 ## Sharing a file or folder
 
 You can create a public or secure, private link for any file or folder
-in your account. When clocking the link, guest users can view, download,
+in your account. When clicking the link, guest users can view, download,
 view metadata and even upload content. Start by selecting your content, and then selecting "share" either from the right click context-menu, or from the top main options bar in the file-list.
 
 ## Searching for Files
 
-You can do simple searches across all of Curate <span style="font-size: 8pt;vertical-align: super;">TM</span> using the search box
+You can do simple searches across all of Curate<span style="font-size: 8pt;vertical-align: super;">TM</span> using the search box
 at the top right of the screen. The simple search is conducted over file
 names and folder names only (not metadata). Complete names or fragments
 of filenames can be used, for example a file called myphotograph.jpg can

--- a/docs/upload-ingest.md
+++ b/docs/upload-ingest.md
@@ -1,7 +1,7 @@
 ## Uploading Files and Folders into Quarantine
 
 Files and Directories can be simple and quickly uploaded into
-Curate <span style="font-size: 8pt;vertical-align: super;">TM</span>, but only into the Personal and Quarantine workspaces. If
+Curate<span style="font-size: 8pt;vertical-align: super;">TM</span>, but only into the Personal and Quarantine workspaces. If
 files are uploaded into the Personal workspace they cannot be moved out
 into any other workspace. Any file which is uploaded or moved into the
 Quarantine workspace will be virus checked and a visual indication given
@@ -10,7 +10,7 @@ is found with a virus is immediately moved to a folder within the
 Quarantine workspace called Infected. Files will be automatically
 re-scanned for viruses after 30 days if they are left in the Quarantine
 workspace, after which time they are then labeled Virus Free and
-available for Release. Curate <span style="font-size: 8pt;vertical-align: super;">TM</span> does not stop you from moving files
+available for Release. Curate<span style="font-size: 8pt;vertical-align: super;">TM</span> does not stop you from moving files
 out of Quarantine at any time you wish.
 
 ## Advanced Web-uploader
@@ -113,7 +113,7 @@ when you procure Curate for your organisation, or send us a support
 ticket.
 
 _Remember, we'd strongly advise you to use the advanced web-uploader for
-most ingest usecases. It's best to only use sftp if your institution
+most ingest use cases. It's best to only use sftp if your institution
 explicitly requires it._
 
 ### Connecting to and Uploading Through SFTP


### PR DESCRIPTION
Ports the still-relevant fixes from the stale #2 onto the current multi-file docs structure. #2 edits the old monolithic `docs/documentation.markdown`, which has since been deleted and split into the per-section files, so it can no longer be merged (modify/delete conflict). This re-applies only the fixes that are genuinely still missing from `main`.

### Changes
- **Typos** (all still live on `main`):
  - `search-access.md`: "When **clocking** the link" -> "clicking"
  - `upload-ingest.md`: "most ingest **usecases**" -> "use cases"
  - `appraisal.md`: "in the **lefthand** column" -> "left hand"
- **Trademark spacing** (29 occurrences across 7 files): removed the space before the `TM` superscript so it attaches to the word (`Curate <sup>TM</sup>` -> `Curate<sup>TM</sup>`), matching how the title already renders. Affects Curate, Archivematica, and Artefactual Systems.
- **Characterisation tools** (`preservation.md`): the four A3M tools (FFProbe / MediaInfo / ExifTool / Fiwalk) were bare lines that render as a single run-on paragraph; now a proper bulleted list (dash style, to satisfy markdownlint MD004/MD007).

### Not ported
The link-style restyle and link de-duplication from #2 don't apply, `main`'s split files never took that rewrite, so there are no duplicate links to remove.

Closes the practical intent of #2.