### PR TITLE
docs: remove stray LLM-preamble line from preservation page

### DIFF
--- a/docs/preservation.md
+++ b/docs/preservation.md
@@ -2,8 +2,6 @@ Curate<span style="font-size: 8pt;vertical-align: super;">TM</span> features a h
 wraps the open source tool A3M into a dynamic workflow. Curate preservation workflows are highly configurable, simple to action,
 and automate the process of performing best-practice preservation and packaging actions on your files and folders.
 
-Here's the enriched version with proper markdown formatting and escaping:
-
 ## About A3M
 
 A3M is an open-source tool, developed by Artefactual Systems<span style="font-size: 8pt;vertical-align: super;">TM</span>, that distills the essential preservation and packaging functionality of their widely-used platform Archivematica<span style="font-size: 8pt;vertical-align: super;">TM</span> into a specialised module. By removing unneeded components like the backend storage management and frontend-application while maintaining the same core code that powers digital archiving programs across the globe, A3M is able to provide reliable, comprehensive preservation and packaging functionalities in entirely new contexts.


### PR DESCRIPTION
Removes a leftover LLM preamble line in `docs/preservation.md`:

> Here's the enriched version with proper markdown formatting and escaping:

It sat between the intro paragraph and the `## About A3M` heading and rendered as a stray sentence on the published Preservation page. It was pasted in with the generated content during authoring (present since the old monolith too), not actual documentation.

Scanned the rest of `docs/` for similar artifacts ("Here's the...", "Sure,", "as an AI", "Let me know if", etc.), this was the only one.